### PR TITLE
Add jump back to previous location support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.vsix
+.vscode
+node_modules

--- a/package.json
+++ b/package.json
@@ -3,14 +3,15 @@
 	"description": "Dumb Jump To Definition",
 	"author": "Vaclav Kral",
 	"license": "MIT",
-	"version": "0.0.3",
+	"version": "0.0.4",
 	"publisher": "vasa81",
 	"engines": {
 		"vscode": "^1.26.0"
 	},
 	"categories": [],
 	"activationEvents": [
-		"onCommand:vscode-dumb-jump.jump"
+		"onCommand:vscode-dumb-jump.jump",
+		"onCommand:vscode-dumb-jump.back"
 	],
 	"main": "./src/main",
 	"contributes": {
@@ -19,13 +20,18 @@
 				"title": "Dumb Jump To Definition",
 				"category": "Search",
 				"command": "vscode-dumb-jump.jump"
+			},
+			{
+				"title": "Dumb Back To Preview Location",
+				"category": "Search",
+				"command": "vscode-dumb-jump.back"
 			}
 		]
 	},
 	"repository": {
 		"type": "git",
-        "url": "https://github.com/vasa81/vscode-dumb-jump.git"
-    },
+		"url": "https://github.com/vasa81/vscode-dumb-jump.git"
+	},
 	"homepage": "https://github.com/vasa81/vscode-dumb-jump",
 	"icon": "icon.png"
 }

--- a/src/main.js
+++ b/src/main.js
@@ -6,6 +6,7 @@ const ChildProcess = require('child_process');
 const { providers } = require('./providers');
 
 let ignoreNextSearch = false;
+let previousLocation = null;
 
 function ripGrepResultToCodeLocation(result) {
     const data = result.split(':');
@@ -149,9 +150,16 @@ function jump(editor) {
     if (range) {
         ripGrepSearch(vscode.workspace.rootPath, word, path.extname(document.fileName)).then(locations => {
             if (locations.length > 0) {
+                previousLocation = new vscode.Location(vscode.Uri.file(document.fileName), range);
                 openLocations(locations);
             }
         });
+    }
+}
+
+function back(editor) {
+    if (previousLocation != null) {
+        return openLocation(previousLocation);
     }
 }
 
@@ -174,6 +182,7 @@ function activate(context) {
     // );
 
     vscode.commands.registerTextEditorCommand('vscode-dumb-jump.jump', jump);
+    vscode.commands.registerTextEditorCommand('vscode-dumb-jump.back', back);
 }
 
 exports.activate = activate;


### PR DESCRIPTION
Hi @vasa81 
vscode-dumb-jump is a useful extension. 

I think it is better to be able to remember and quickly return to the previous position after each jump to the definition.

This feature can provide more convenience when reading the code.