### PR TITLE
Add configuration to set path to rg

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"description": "Dumb Jump To Definition",
 	"author": "Vaclav Kral",
 	"license": "MIT",
-	"version": "0.0.4",
+	"version": "0.0.5",
 	"publisher": "vasa81",
 	"engines": {
 		"vscode": "^1.26.0"
@@ -26,7 +26,16 @@
 				"category": "Search",
 				"command": "vscode-dumb-jump.back"
 			}
-		]
+		],
+		"configuration": {
+			"title": "Dumb Jump",
+			"properties": {
+				"dumbJump.pathToRipGrep": {
+					"title": "Path to RipGrep",
+					"type": "string"
+				}
+			}
+		}
 	},
 	"repository": {
 		"type": "git",

--- a/src/main.js
+++ b/src/main.js
@@ -79,6 +79,10 @@ function getSearchOptions(word, fileExt) {
     }
 }
 
+function getRipGrepPath() {
+    return vscode.workspace.getConfiguration('dumbJump').get('pathToRipGrep') || "rg"
+}
+
 async function ripGrepSearch(scanPaths, word, fileExt) {
     const { regex, fileTypes } = getSearchOptions(word, fileExt)
 
@@ -92,7 +96,7 @@ async function ripGrepSearch(scanPaths, word, fileExt) {
     args.push(scanPaths);
 
     return new Promise((resolve, reject) => {
-        const runRipgrep = ChildProcess.spawn('rg', args);
+        const runRipgrep = ChildProcess.spawn(getRipGrepPath(), args);
 
         runRipgrep.stdout.setEncoding('utf8');
         runRipgrep.stderr.setEncoding('utf8');


### PR DESCRIPTION
On a Mac where RipGrep is installed via homebrew `rg` doesn't appear to be in the PATH accessible by the extension