### PR TITLE
Add support for multi folder workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,13 @@
 	"description": "Dumb Jump To Definition",
 	"author": "Vaclav Kral",
 	"license": "MIT",
-	"version": "0.0.5",
+	"version": "0.0.6",
 	"publisher": "vasa81",
 	"engines": {
 		"vscode": "^1.26.0"
+	},
+	"scripts": {
+		"package": "vsce package"
 	},
 	"categories": [],
 	"activationEvents": [
@@ -33,6 +36,11 @@
 				"dumbJump.pathToRipGrep": {
 					"title": "Path to RipGrep",
 					"type": "string"
+				},
+				"dumbJump.searchAllWorkspaceFolders": {
+					"title": "Search all workspace folders",
+					"type": "boolean",
+					"description": "If enabled in a multi-workspace project all workspace folders will be searched. Otherwise only the document workspace is searched."
 				}
 			}
 		}


### PR DESCRIPTION
The current code uses workspace.rootPath, which has since been deprecated. This means that if you jump to a definition in a multi-folder workspace it will only search the first folder.

This PR updates this behaviour to use `workspaceFolders` and build an array of search paths.

As searching all paths might be slower for large workspaces the PR also adds a configuration to toggle searching all workspace folders or only the folder of the current file. If this is unchecked then it uses `getWorkspaceFolder` to limit the paths. The configuration is toggled off by default to retain the prior behaviour.
