### PR TITLE
Add a regex for Ruby for namespaced classes and modules

### DIFF
--- a/src/providers.js
+++ b/src/providers.js
@@ -90,6 +90,7 @@ exports.providers = {
         /(^|\s)attr_writer\s+:{word}(\s|$)/,
         /(^|\s)define_method\s+:?{word}\s*\(?/,
         /(^|\s){word}\s*=(\s|$)/,
+        /(^|\s)(?:class|module)\s+(?:[A-Z]\w*::)+{word}(\s|$)/,
       ],
       extensions: ['*.rb', '*.ru', '*.haml', '*.erb', '*.rake'],
     },


### PR DESCRIPTION
Ruby classes can be namespaced like `class Something::Name`. Add a lower priority regex for finding that style of class or module.